### PR TITLE
mongodb v8.2.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.16" %}
+{% set version = "8.2.6" %}
 
 package:
   name: mongodb
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mongodb/mongo/archive/refs/tags/r{{ version }}.tar.gz
-  sha256: 8426949b47e8b0d6b8a048b698c2f80c856464bef4344752dc16f20efd6b10cf
+  sha256: a9ace7e055c926ad35a1144ac652f32e8e66e6f900fcc85bbc6cb585505853e7
   patches:
     - patches/0001-Do-not-inject-debug-info-unnecessarily.patch
     - patches/0002-Fix-icu-namespace-extension-for-un-vendored-icu.patch
@@ -30,7 +30,7 @@ source:
     - patches/0019-add-missing-header-for-uint16_t.patch
 
 build:
-  number: 1
+  number: 0
   detect_binary_files_with_prefix: false
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]


### PR DESCRIPTION

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
  * Not sure if conda-smithy is still the right way to rerender package spec files. I did have a `conda render` command available and did `conda render .` within the root of the repo directry. It appeared to rerender package specs, but issued this warning/error:

```
samueldy@login01 mongodb-feedstock $ conda render .
WARNING: Number of parsed outputs does not match detected raw metadata blocks. Identified output block may be wrong! If you are using Jinja conditionals to include or excl
ude outputs, consider using `skip: true  # [condition]` instead.
WARNING: failed to get package records, retrying.  exception was: Unsatisfiable dependencies for platform linux-64: {MatchSpec("c_linux-64")}
Encountered problems while solving:
  - unsupported request

Could not solve for environment specs
The following package could not be installed
└─ c_linux-64 =* * does not exist (perhaps a typo or a missing channel).
ERROR: Failed to get package records, max retries exceeded.
WARNING: Returning non-final recipe for mongodb-8.2.6-0; one or more dependencies was unsatisfiable:
WARNING: Build: c_linux-64
```

* [X] Ensured the license file is being packaged.
  * Not sure how to ensure this, but I didn't change any license-related content so I believe the license files should still be packaged.

<hr />

This pull request attempts to update the conda-feedstock version of MongoDB to 8.2.6, which appears to be the latest available version with a release tag on GitHub.